### PR TITLE
Adds configurable log file location

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,12 +14,30 @@ import (
 	"github.com/derricw/siggo/widgets"
 )
 
-var Mock string
-var Debug bool
+var (
+	Mock  string
+	Debug bool
+)
+
+const defaultLogPath = "/tmp/siggo.log"
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&Mock, "mock", "m", "", "mock mode (uses example data)")
 	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "d", false, "debug logging")
+}
+
+func initLogging(cfg *model.Config) {
+	if cfg.LogFilePath == "" {
+		cfg.LogFilePath = defaultLogPath
+	}
+	logFile, err := os.Create(cfg.LogFilePath)
+	if err != nil {
+		log.Fatal("error creating log file: %v %v", cfg.LogFilePath, err)
+	}
+	if Debug {
+		log.SetLevel(log.DebugLevel)
+	}
+	log.SetOutput(logFile)
 }
 
 var rootCmd = &cobra.Command{
@@ -27,19 +45,13 @@ var rootCmd = &cobra.Command{
 	Short: "siggo is a terminal gui for signal-cli",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		outputFile, err := os.Create("/tmp/siggo.log")
-		if err != nil {
-			log.Fatal(err)
-		}
-		if Debug {
-			log.SetLevel(log.DebugLevel)
-		}
-		log.SetOutput(outputFile)
-
 		cfg, err := model.GetConfig()
 		if err != nil {
 			log.Fatal("failed to read config @ %s", model.DefaultConfigPath())
 		}
+
+		initLogging(cfg)
+
 		if cfg.UserNumber == "" {
 			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
 		}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,5 @@ require (
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/cobra v0.0.7
 	github.com/stretchr/testify v1.5.1
-	gitlab.com/domaintools/application/gathering/gathercli v0.0.0-20200512171528-364bbdfaa1ff // indirect
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/model/config.go
+++ b/model/config.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 )
 
-var configFilename string = "config.yml"
-var configFolder string = ".siggo"
+var (
+	configFilename string = "config.yml"
+	configFolder   string = ".siggo"
+)
 
 func DefaultConfigFolder() string {
 	d, _ := os.UserHomeDir()
@@ -45,6 +47,9 @@ type Config struct {
 	HidePhoneNumbers      bool              `yaml:"hide_phone_numbers"`
 	ContactColors         map[string]string `yaml:"contact_colors"`
 	ContactAliases        map[string]string `yaml:"contact_aliases"`
+
+	// No rotation provided, use at your own risk!
+	LogFilePath string `yaml:"log_file"`
 }
 
 // SaveAs writes the config to `path`


### PR DESCRIPTION
    Add log_file to config options
    
    Writes the log messages to a user-configurable location.  Still defaults
    to "/tmp/siggo.log" when the config contains no information.
