### PR TITLE
use XDG directories for data and config

### DIFF
--- a/cmd/cfg.go
+++ b/cmd/cfg.go
@@ -75,7 +75,7 @@ var cfgColorCmd = &cobra.Command{
 				log.Fatalf("couldn't load current config: %s", err)
 			}
 			if cfg.UserNumber == "" {
-				log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+				log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 			}
 			// make sure contact exists?
 			// make sure color exists
@@ -128,7 +128,7 @@ var cfgAliasCmd = &cobra.Command{
 				log.Fatalf("couldn't load current config: %s", err)
 			}
 			if cfg.UserNumber == "" {
-				log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+				log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 			}
 			// set alias and save config
 			cfg.ContactAliases[contactName] = alias

--- a/cmd/contacts.go
+++ b/cmd/contacts.go
@@ -21,10 +21,10 @@ var contactsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := model.GetConfig()
 		if err != nil {
-			log.Fatalf("failed to read config @ %s", model.DefaultConfigPath())
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
 		}
 		if cfg.UserNumber == "" {
-			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+			log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 		}
 		signalAPI := signal.NewSignal(cfg.UserNumber)
 		s := model.NewSiggo(signalAPI, cfg)

--- a/cmd/conv.go
+++ b/cmd/conv.go
@@ -23,10 +23,10 @@ var convCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := model.GetConfig()
 		if err != nil {
-			log.Fatalf("failed to read config @ %s", model.DefaultConfigPath())
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
 		}
 		if cfg.UserNumber == "" {
-			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+			log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 		}
 
 		var signalAPI model.SignalAPI = signal.NewSignal(cfg.UserNumber)

--- a/cmd/receive.go
+++ b/cmd/receive.go
@@ -18,12 +18,12 @@ var receiveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := model.GetConfig()
 		if err != nil {
-			log.Fatalf("failed to read config @ %s", model.DefaultConfigPath())
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
 		}
 		initLogging(cfg)
 
 		if cfg.UserNumber == "" {
-			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+			log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 		}
 
 		var signalAPI model.SignalAPI = signal.NewSignal(cfg.UserNumber)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func init() {
 
 func initLogging(cfg *model.Config) {
 	if cfg.LogFilePath == "" {
-		cfg.LogFilePath = defaultLogPath
+		cfg.LogFilePath = model.LogPath()
 	}
 	logFile, err := os.Create(cfg.LogFilePath)
 	if err != nil {
@@ -65,14 +65,14 @@ var rootCmd = &cobra.Command{
 
 		cfg, err := model.GetConfig()
 		if err != nil {
-			log.Fatalf("failed to read config @ %s", model.DefaultConfigPath())
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
+		}
+
+		if cfg.UserNumber == "" {
+			log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 		}
 
 		initLogging(cfg)
-
-		if cfg.UserNumber == "" {
-			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
-		}
 
 		var signalAPI model.SignalAPI = signal.NewSignal(cfg.UserNumber)
 		if mock != "" {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -19,10 +19,10 @@ var sendCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := model.GetConfig()
 		if err != nil {
-			log.Fatalf("failed to read config @ %s", model.DefaultConfigPath())
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
 		}
 		if cfg.UserNumber == "" {
-			log.Fatalf("no user phone number configured @ %s", model.DefaultConfigPath())
+			log.Fatalf("no user phone number configured @ %s", model.ConfigPath())
 		}
 		sig := signal.NewSignal(cfg.UserNumber)
 		ID, err := sig.Send(args[0], args[1])

--- a/model/config.go
+++ b/model/config.go
@@ -10,21 +10,44 @@ import (
 )
 
 var (
-	configFilename string = "config.yml"
-	configFolder   string = ".siggo"
+	configFilename   string = "config.yml"
+	configFolderName string = "siggo"
+	dataFolderName   string = "siggo"
 )
 
-func DefaultConfigFolder() string {
+// FindConfigFolder returns $XDG_CONFIG_HOME/siggo/ if it exists, otherwise returns $HOME/.config/siggo/
+func FindConfigFolder() string {
+	XDGConfig := os.Getenv("XDG_CONFIG_HOME")
+	if XDGConfig != "" {
+		return filepath.Join(XDGConfig, configFolderName)
+	}
 	d, _ := os.UserHomeDir()
-	return filepath.Join(d, configFolder)
+	return filepath.Join(d, ".config", configFolderName)
 }
 
-func DefaultConfigPath() string {
-	return filepath.Join(DefaultConfigFolder(), configFilename)
+// ConfigPath returns the config file path
+func ConfigPath() string {
+	return filepath.Join(FindConfigFolder(), configFilename)
 }
 
+// FindDataFolder returns $XDG_DATA_HOME if it exists, otherwise returns $HOME/.local/share/siggo/
+func FindDataFolder() string {
+	XDGData := os.Getenv("XDG_DATA_HOME")
+	if XDGData != "" {
+		return filepath.Join(XDGData, dataFolderName)
+	}
+	d, _ := os.UserHomeDir()
+	return filepath.Join(d, ".local", "share", dataFolderName)
+}
+
+// ConversationFolder returns the folder where conversations are saved
 func ConversationFolder() string {
-	return filepath.Join(DefaultConfigFolder(), "conversations")
+	return filepath.Join(FindDataFolder(), "conversations")
+}
+
+// LogPath returns the log file path
+func LogPath() string {
+	return filepath.Join(FindDataFolder(), "siggo.log")
 }
 
 func DefaultConfig() *Config {
@@ -73,7 +96,7 @@ func (c *Config) SaveAs(path string) error {
 
 // Save saves the config to the default location
 func (c *Config) Save() error {
-	return c.SaveAs(DefaultConfigPath())
+	return c.SaveAs(ConfigPath())
 }
 
 // Print pretty-prints the configuration
@@ -112,7 +135,7 @@ func NewConfigFile(path string) (*Config, error) {
 // GetConfig returns the current configuration from the
 // default config location, creates a new one if it isn't there
 func GetConfig() (*Config, error) {
-	path := DefaultConfigPath()
+	path := ConfigPath()
 	if _, err := os.Stat(path); err != nil {
 		// config doesn't exist so lets save default
 		return NewConfigFile(path)

--- a/model/model.go
+++ b/model/model.go
@@ -34,6 +34,7 @@ type Contact struct {
 	Alias  string
 }
 
+// String returns a string to display for this contact. Priority is Alias > Name > Number.
 func (c *Contact) String() string {
 	if c.Alias != "" {
 		return c.Alias


### PR DESCRIPTION
This should fix issue #5.

We use the XDG default folders for config files (`$HOME/.config/siggo`) and data (`$HOME/.local/share/siggo`) unless overridden by $XDG_CONFIG_HOME or $XDG_DATA_HOME.