### PR TITLE
Minimal attachment sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bin
 examples.json
+dist
+cov.cov
+coverage.html

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ bin/siggo
 * `k` - Scroll Up
 * `J` - Next Contact
 * `K` - Previous Contact
+* `a` - Attach file (sent with next message)
 * `i` - Insert Mode
   * `CTRL+L` - Clear input field
 * `I` - Compose (opens $EDITOR and lets you make a fancy message)
@@ -107,7 +108,6 @@ Here is a list of things that are currently broken.
 
 Here is a list of features I'd like to add soonish.
 * Better Attachments Support
-  * Sending attachments
   * Opening attachments (besides the most recent)
 * gui configuration
   * colors and border styles

--- a/signal/message.go
+++ b/signal/message.go
@@ -60,6 +60,11 @@ type Attachment struct {
 
 // Path returns the full path to an attachment file
 func (a *Attachment) Path() (string, error) {
+	if a.ID == "" {
+		// TODO: save our own copy of the attachment with our own ID
+		// for now, just return the path where we attached it
+		return a.Filename, nil
+	}
 	folder, err := GetSignalFolder()
 	if err != nil {
 		return "", err

--- a/signal/mock.go
+++ b/signal/mock.go
@@ -57,7 +57,7 @@ func (ms *MockSignal) Send(dest, msg string) (int64, error) {
 	return timestamp, nil
 }
 
-func (ms *MockSignal) SendDbus(dest, msg string) (int64, error) {
+func (ms *MockSignal) SendDbus(dest, msg string, attachments ...string) (int64, error) {
 	return ms.Send(dest, msg)
 }
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -235,11 +235,17 @@ func (s *Signal) Send(dest, msg string) (int64, error) {
 }
 
 // SendDbus does the same thing as Send but it goes through a running daemon.
-func (s *Signal) SendDbus(dest, msg string) (int64, error) {
+func (s *Signal) SendDbus(dest, msg string, attachments ...string) (int64, error) {
 	if !strings.HasPrefix(dest, "+") {
 		dest = fmt.Sprintf("+%s", dest)
 	}
-	cmd := exec.Command("signal-cli", "--dbus", "send", dest, "-m", msg)
+	args := []string{"--dbus", "send", dest, "-m", msg}
+	if len(attachments) > 0 {
+		// how do I do this in one line?
+		args = append(args, "-a")
+		args = append(args, attachments...)
+	}
+	cmd := exec.Command("signal-cli", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		s.publishError(err)


### PR DESCRIPTION
Added a panel that allows you to specify a file to attach (currently with no auto-complete) to the current conversation.

It will be sent with the next outgoing message in the conversation.

Multiple attachments can be sent with a message.