### PR TITLE
Feature/macos support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A terminal gui for signal-cli, written in Go.
 
 * [signal-cli](https://github.com/AsamK/signal-cli). (>=0.6.7)
 
-siggo uses the dbus daemon feature of signal-cli, so `libunixsocket-java` (Debian) or `libmatthew-unix-java` (AUR) is required.
+siggo uses the dbus daemon feature of signal-cli, so `libunixsocket-java` (Debian) or `libmatthew-unix-java` (AUR) is required. There may be a `brew` forumla for dbus on MacOS.
 
 Install signal-cli and put it somewhere safe in your path. You will need to follow its instructions to either [link](https://github.com/AsamK/signal-cli/wiki/Linking-other-devices-(Provisioning)) or [register](https://github.com/AsamK/signal-cli#usage) your device. The `siggo link <phonenumber> <devicename>` subcommand has been added to make linking more user-friendly, but has not been tested sufficiently. Be sure to prefix with `+` and country code (for example `+12345678901`).
 
@@ -35,6 +35,8 @@ You are now ready to use `siggo`.
 siggo shells out to `signal-cli`, so if that worries you, don't use it, for now. I have lofty goals of eventually replacing this with [libsignal](https://github.com/signalapp/libsignal-protocol-c).
 
 ### Build
+
+siggo should build on Linux or MacOS, but it has only been tested on Linux.
 
 ```
 make build

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,7 +94,7 @@ var rootCmd = &cobra.Command{
 
 		// finally, start the tview app
 		if err := app.SetRoot(chatWindow, true).SetFocus(chatWindow).Run(); err != nil {
-			signalAPI.Close()
+			signalAPI.Close() // redundant?
 			panic(err)
 		}
 		// clean up when we're done

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	ossig "os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/rivo/tview"
 	log "github.com/sirupsen/logrus"
@@ -92,6 +94,17 @@ var rootCmd = &cobra.Command{
 		app := tview.NewApplication()
 		chatWindow := widgets.NewChatWindow(s, app)
 
+		// also want to make sure to handle signals
+		sigChan := make(chan os.Signal, 1)
+		ossig.Notify(sigChan, os.Interrupt, os.Kill, syscall.SIGINT,
+			syscall.SIGTERM, syscall.SIGKILL, syscall.SIGABRT, syscall.SIGIOT,
+			syscall.SIGQUIT) // doesn't catch syscall.SIGKILL but might as well include it
+		go func() {
+			s := <-sigChan
+			log.Infof("caught signal: %s", s)
+			chatWindow.Quit()
+		}()
+
 		// finally, start the tview app
 		if err := app.SetRoot(chatWindow, true).SetFocus(chatWindow).Run(); err != nil {
 			signalAPI.Close() // redundant?
@@ -104,7 +117,6 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,7 @@ var rootCmd = &cobra.Command{
 		if mock != "" {
 			signalAPI = setupMock(mock, cfg)
 		}
+		defer signalAPI.Close()
 
 		s := model.NewSiggo(signalAPI, cfg)
 
@@ -93,6 +94,7 @@ var rootCmd = &cobra.Command{
 
 		// finally, start the tview app
 		if err := app.SetRoot(chatWindow, true).SetFocus(chatWindow).Run(); err != nil {
+			signalAPI.Close()
 			panic(err)
 		}
 		// clean up when we're done

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,7 +98,7 @@ var rootCmd = &cobra.Command{
 		sigChan := make(chan os.Signal, 1)
 		ossig.Notify(sigChan, os.Interrupt, os.Kill, syscall.SIGINT,
 			syscall.SIGTERM, syscall.SIGKILL, syscall.SIGABRT, syscall.SIGIOT,
-			syscall.SIGQUIT) // doesn't catch syscall.SIGKILL but might as well include it
+			syscall.SIGQUIT, syscall.SIGSEGV) // doesn't catch syscall.SIGKILL but might as well include it
 		go func() {
 			s := <-sigChan
 			log.Infof("caught signal: %s", s)

--- a/model/model.go
+++ b/model/model.go
@@ -289,6 +289,7 @@ type SignalAPI interface {
 	SendDbus(string, string, ...string) (int64, error)
 	Receive() error
 	ReceiveForever()
+	Close()
 	OnReceived(signal.ReceivedCallback)
 	OnReceipt(signal.ReceiptCallback)
 	OnSent(signal.SentCallback)
@@ -527,6 +528,7 @@ func (s *Siggo) Quit() {
 	if s.config.SaveMessages {
 		s.SaveConversations()
 	}
+	s.signal.Close() // should kill daemon?
 }
 
 // NewSiggo creates a new model

--- a/model/model.go
+++ b/model/model.go
@@ -528,7 +528,7 @@ func (s *Siggo) Quit() {
 	if s.config.SaveMessages {
 		s.SaveConversations()
 	}
-	s.signal.Close() // should kill daemon?
+	s.signal.Close() // kills the signal-cli daemon
 }
 
 // NewSiggo creates a new model

--- a/signal/mock.go
+++ b/signal/mock.go
@@ -82,6 +82,8 @@ func (ms *MockSignal) ReceiveForever() {
 	}()
 }
 
+func (ms *MockSignal) Close() {}
+
 func NewMockSignal(userNumber string, exampleData []byte) *MockSignal {
 	return &MockSignal{
 		Signal:      NewSignal(userNumber),

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	//"syscall"
 	"time"
 
 	qr "github.com/mdp/qrterminal/v3"

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
+	//"syscall"
 	"time"
 
 	qr "github.com/mdp/qrterminal/v3"
@@ -189,11 +189,17 @@ func (s *Signal) ReceiveForever() {
 // Daemon starts the dbus daemon and receives forever.
 func (s *Signal) Daemon() error {
 	cmd := exec.Command("signal-cli", "-u", s.uname, "daemon", "--json")
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		//Pdeathsig: syscall.SIGKILL,
-		//Setsid:  true,
-		//Setpgid: true,
-	}
+
+	//  This is the only way to ensure that the signal-cli daemon is killed when we get
+	//  SIGKILL, but it isn't available on MacOS, so we leave it commented out for now.
+	//  This means that SIGKILL will leave a zombie signal-cli daemon running that will have to be
+	//  killed manually. I have tried unsuccessfully to find a cross-platform solution for this.
+	//  Other signals, like SIGTERM and SIGINT should be handled correctly.
+
+	//cmd.SysProcAttr = &syscall.SysProcAttr{
+	//Pdeathsig: syscall.SIGKILL,
+	//}
+
 	outReader, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -359,7 +365,7 @@ func (s *Signal) ProcessWire(wire []byte) error {
 func (s *Signal) Close() {
 	if s.daemon != nil {
 		log.Debug("killing signal-cli daemon...")
-		_ = s.daemon.Process.Kill()
+		_ = s.daemon.Process.Signal(os.Interrupt)
 	}
 }
 

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -191,7 +191,7 @@ func (s *Signal) Daemon() error {
 
 	//  This is the only way to ensure that the signal-cli daemon is killed when we get
 	//  SIGKILL, but it isn't available on MacOS, so we leave it commented out for now.
-	//  This means that SIGKILL will leave a zombie signal-cli daemon running that will have to be
+	//  This means that SIGKILL will leave an orphaned signal-cli daemon running that will have to be
 	//  killed manually. I have tried unsuccessfully to find a cross-platform solution for this.
 	//  Other signals, like SIGTERM and SIGINT should be handled correctly.
 

--- a/widgets/chatwindow.go
+++ b/widgets/chatwindow.go
@@ -404,7 +404,6 @@ func (c *ChatWindow) ShowTempSentMsg(msg string) {
 // Quit shuts down gracefully
 func (c *ChatWindow) Quit() {
 	c.app.Stop()
-	// do we need to do anything else?
 	c.siggo.Quit()
 	os.Exit(0)
 }


### PR DESCRIPTION
This is an attempt to replace the use of `syscall.Pdeathsig` (since it is not available on MacOS).

It was used to ensure that the `signal-cli` daemon subprocess is killed whenever `siggo` is killed.

A replacement needs to ensure that the daemon is killed for all reasonable scenarios.