### PR TITLE
Bug/fix initial edge cases

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,10 @@ var rootCmd = &cobra.Command{
 			cfg.UserNumber = fmt.Sprintf("+%s", cfg.UserNumber)
 		}
 
+		if len(cfg.UserNumber) < 12 {
+			log.Fatalf("user phone number: %s is too short. did you forget a country code?", cfg.UserNumber)
+		}
+
 		initLogging(cfg)
 
 		var signalAPI model.SignalAPI = signal.NewSignal(cfg.UserNumber)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	ossig "os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -34,6 +35,13 @@ func initLogging(cfg *model.Config) {
 	if cfg.LogFilePath == "" {
 		cfg.LogFilePath = model.LogPath()
 	}
+
+	dir := filepath.Dir(cfg.LogFilePath)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		log.Fatalf("failed to create folder: %s", dir)
+	}
+
 	logFile, err := os.Create(cfg.LogFilePath)
 	if err != nil {
 		log.Fatalf("error creating log file: %v %v", cfg.LogFilePath, err)

--- a/widgets/chatwindow.go
+++ b/widgets/chatwindow.go
@@ -448,13 +448,22 @@ func (c *ChatWindow) Quit() {
 
 func (c *ChatWindow) update() {
 	convs := c.siggo.Conversations()
-	if convs != nil {
+	if convs != nil && len(convs) > 0 {
+		if c.currentContact == nil {
+			// there is a conversation but we haven't set a current contact yet
+			// just grab the first one we find
+			for _, contact := range c.siggo.Contacts() {
+				c.currentContact = contact
+				break
+			}
+		}
 		c.contactsPanel.Render()
 		currentConv, ok := convs[c.currentContact]
 		if ok {
 			c.conversationPanel.Update(currentConv)
 		} else {
-			panic("no conversation for current contact")
+			// this is a panic because it shouldn't be possible?
+			log.Panicf("no conversation for current contact: %s", c.currentContact)
 		}
 	}
 }
@@ -689,6 +698,7 @@ func NewChatWindow(siggo *model.Siggo, app *tview.Application) *ChatWindow {
 
 	w.siggo = siggo
 	contacts := siggo.Contacts().SortedByIndex()
+	log.Debugf("contacts found: %v", contacts)
 	if len(contacts) > 0 {
 		w.currentContact = contacts[0]
 	}


### PR DESCRIPTION
Fixes some errors that can pop up after initial `signal-cli` setup.

* Fix panic that can occur when message saving is disabled, and no conversations are found initially.
* Fixed an error where the siggo data folder was not getting created before the log file.
* Added check to ensure that the user number has a country code.