### PR TITLE
Make link command write siggo config

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/derricw/siggo/model"
 	"github.com/derricw/siggo/signal"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -22,5 +24,12 @@ var linkCmd = &cobra.Command{
 		fmt.Println("linking...")
 		sig := signal.NewSignal(args[0])
 		sig.Link(args[1])
+
+		cfg, err := model.GetConfig()
+		if err != nil {
+			log.Fatalf("failed to read config @ %s", model.ConfigPath())
+		}
+		cfg.UserNumber = args[0]
+		cfg.Save()
 	},
 }


### PR DESCRIPTION
This will make `siggo link` write the phone number to siggo's own config when successful. Before, new users might get confused why they get "no user phone number configured" first time running siggo after linking, because they had to manually set the number in the config.