### PR TITLE
Add support for attaching content in clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you are updating from a previous version, I recommend deleting your conversat
   * `Enter` - Open selected link in browser
   * `ll` - Open Last URL
   * `y` - Yank selected link to clipboard
+* `p` or `CTRL+V` - Paste text/attach file in clipboard
 * `ESC` - Normal Mode
 * `CTRL+N` - Move to next conversation with unread messages
 * `CTRL+Q` - Quit (`CTRL+C` _should_ also work)

--- a/widgets/attach.go
+++ b/widgets/attach.go
@@ -3,12 +3,16 @@ package widgets
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"mime"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	"github.com/gdamore/tcell"
 	"github.com/rivo/tview"
 	log "github.com/sirupsen/logrus"
@@ -91,4 +95,50 @@ func FZFFile() (string, error) {
 	f := strings.TrimSpace(buf.String())
 	path := filepath.Join(usr.HomeDir, f)
 	return path, err
+}
+
+// Attach a file directly from clipboard
+func AttachFromClipboard(parent *ChatWindow) error {
+	content, err := clipboard.ReadAll()
+	if err != nil {
+		return err
+	}
+
+	contentBytes := []byte(content)
+	mimetype := http.DetectContentType(contentBytes)
+
+	if strings.HasPrefix(mimetype, "text/") {
+		// If clipboard contains text, paste it instead of attaching
+		parent.sendPanel.SetText(parent.sendPanel.GetText() + content)
+		parent.InsertMode()
+		return nil
+	}
+
+	ext, err := mime.ExtensionsByType(mimetype)
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := ioutil.TempFile("", "*"+ext[0])
+	if err != nil {
+		return err
+	}
+	if _, err = tmpFile.Write(contentBytes); err != nil {
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+
+	conv, err := parent.currentConversation()
+	if err != nil {
+		return err
+	}
+	if err := conv.AddAttachment(tmpFile.Name()); err != nil {
+		return err
+	}
+	parent.sendPanel.Update()
+	parent.InsertMode()
+
+	return nil
 }

--- a/widgets/chatwindow.go
+++ b/widgets/chatwindow.go
@@ -299,6 +299,15 @@ func (c *ChatWindow) NextUnreadMessage() error {
 	return nil
 }
 
+func (c *ChatWindow) Paste() error {
+	err := AttachFromClipboard(c)
+	if err != nil {
+		c.SetErrorStatus(err)
+	}
+
+	return err
+}
+
 // TODO: remove code duplication with ContactDown()
 func (c *ChatWindow) ContactUp() {
 	log.Debug("PREVIOUS CONVERSATION")
@@ -552,6 +561,9 @@ func NewChatWindow(siggo *model.Siggo, app *tview.Application) *ChatWindow {
 			case 65: // a
 				w.FancyAttach()
 				return nil
+			case 112: // p
+				w.Paste()
+				return nil
 			}
 			// pass some events on to the conversation panel
 		case tcell.KeyCtrlQ:
@@ -583,6 +595,9 @@ func NewChatWindow(siggo *model.Siggo, app *tview.Application) *ChatWindow {
 			return nil
 		case tcell.KeyCtrlN:
 			w.NextUnreadMessage()
+			return nil
+		case tcell.KeyCtrlV:
+			w.Paste()
 			return nil
 		}
 		return event


### PR DESCRIPTION
This adds a feature that when in normal mode, pressing `p` or `CTRL+V` will paste the current text from clipboard, or if it's file (such as an image) it will attach it to the message.

A limitation with this solution is that attached files will be stored in a temporary file, so they are not persisant. I'm open for suggestions on a better way to store them.

Also, I wasn't able to bind CTRL+Shift+V in normal mode, but I think this paste method should be used there as well.