### PR TITLE
make request for v2 group names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ examples.json
 dist
 cov.cov
 coverage.html
+*.swp

--- a/signal/mock.go
+++ b/signal/mock.go
@@ -86,6 +86,10 @@ func (ms *MockSignal) ReceiveForever() {
 	}()
 }
 
+func (ms *MockSignal) RequestGroupInfo() ([]SignalGroupInfo, error) {
+	return []SignalGroupInfo{}, nil
+}
+
 func (ms *MockSignal) Close() {}
 
 func NewMockSignal(userNumber string, exampleData []byte) *MockSignal {


### PR DESCRIPTION
`signal-cli` does not put the V2 group names in the data file. So I needed to add a request to get the group names to the initialization procedure.

Unfortunately, this request seems to silently fail if the dbus daemon is already running, so I had to add a channel so that the daemon can wait for it to complete before starting.