### PR TITLE
Feature/0.8.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A terminal ui for signal-cli, written in Go.
 
 ### Dependencies
 
-* [signal-cli](https://github.com/AsamK/signal-cli). (>=0.7.4)
+* [signal-cli](https://github.com/AsamK/signal-cli). (>=0.8.2)
 
 siggo uses the dbus daemon feature of signal-cli, so `libunixsocket-java` (Debian), `libmatthew-java` (Fedora) or `libmatthew-unix-java` (AUR) is required. There seems to be a `brew` [forumla](https://formulae.brew.sh/formula/dbus) for dbus on MacOS.
 

--- a/model/model.go
+++ b/model/model.go
@@ -849,28 +849,24 @@ func (s *Siggo) getContacts() ContactList {
 		return list
 	}
 	for _, c := range contacts {
-		if c.InboxPosition != nil {
-			// strip the weird-ass unicode that we seem to be reading
-			// for some unknown reason
-			name := strings.Trim(c.Name, "\u2068\u2069")
-			alias := ""
-			if s.config.ContactAliases != nil {
-				alias = s.config.ContactAliases[name]
-			}
-			// check if we have a color for this contact
-			color := s.config.ContactColors[name]
-			contact := &Contact{
-				Number: c.Number,
-				Name:   name,
-				Index:  *c.InboxPosition,
-				alias:  alias,
-				color:  color,
-			}
-			list[c.Number] = contact
-			if *c.InboxPosition > highestIndex {
-				highestIndex = *c.InboxPosition
-			}
+		// strip the weird-ass unicode that we seem to be reading
+		// for some unknown reason
+		name := strings.Trim(c.Name, "\u2068\u2069")
+		alias := ""
+		if s.config.ContactAliases != nil {
+			alias = s.config.ContactAliases[name]
 		}
+		// check if we have a color for this contact
+		color := s.config.ContactColors[name]
+		contact := &Contact{
+			Number: c.Number,
+			Name:   name,
+			Index:  highestIndex,
+			alias:  alias,
+			color:  color,
+		}
+		list[c.Number] = contact
+		highestIndex++
 	}
 
 	// get all groups from disk

--- a/signal/signal.go
+++ b/signal/signal.go
@@ -93,7 +93,7 @@ type SignalRecipientStore struct {
 }
 
 func (r *SignalRecipientStore) AsContacts() []*SignalContact {
-	contacts := []*SignalContact{}
+	contacts := make([]*SignalContact, 0)
 	for _, c := range r.Recipients {
 		contacts = append(contacts, c.AsContact())
 	}


### PR DESCRIPTION
signal-cli moved the file where they kept the recipients list in `0.8.2`. this lets us now read from the new location if we don't find anything in the old one.

it doesn't _quite_ drop support for <0.8.2, but I am not going to worry about supporting it going forward.